### PR TITLE
GRC: Fix order of arguments

### DIFF
--- a/grc/dsd_block_ff.xml
+++ b/grc/dsd_block_ff.xml
@@ -4,7 +4,7 @@
   <key>dsd_block_ff</key>
   <category>DSD</category>
   <import>import dsd</import>
-  <make>dsd.block_ff($frame,$mod,$uvquality,$verbosity,$errorbars)</make>
+  <make>dsd.block_ff($frame,$mod,$uvquality,$errorbars,$verbosity)</make>
   <param>
     <name>Frame type</name>
     <key>frame</key>


### PR DESCRIPTION
Fix order of arguments to dsd.block_ff to actually match the function signature.