### PR TITLE
Bug fix for segmentation fault error.

### DIFF
--- a/dsd/src/p25p1_heuristics.c
+++ b/dsd/src/p25p1_heuristics.c
@@ -271,6 +271,11 @@ int estimate_symbol(int rf_mod, P25Heuristics* heuristics, int previous_dibit, i
 	// Use previous_dibit as it comes.
 #endif
 
+	if (previous_dibit > 3 || previous_dibit < 0)
+	{
+		previous_dibit = 0;
+	}
+
     valid = 1;
 
     // Check if we have enough values to model the Gaussians for each symbol involved.


### PR DESCRIPTION
Sometimes there was a "segmentation fault" error. It appeared because there was garbage in the variable "previous_dibit". Most likely this variable is not initialized.
This is not the best solution, but it eliminates this bug.

Fix #123