### PR TITLE
Initialize last_dibit variable to prevent segfault

### DIFF
--- a/dsd/src/dsd_main.c
+++ b/dsd/src/dsd_main.c
@@ -237,6 +237,8 @@ initState (dsd_state * state)
   state->debug_header_errors = 0;
   state->debug_header_critical_errors = 0;
 
+  state->last_dibit = 0;
+
 #ifdef TRACE_DSD
   state->debug_sample_index = 0;
   state->debug_label_file = NULL;


### PR DESCRIPTION
Replaces #15.

@devnulling reported that this fix works, so I'll merge it.